### PR TITLE
Adding stem support to the site

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -145,6 +145,7 @@ asciidoc:
   - ./lib/multirow-table-head-tree-processor.js
   - ./lib/swagger-ui-block-macro.js
   - ./lib/tabs-block.js
+  - '@djencks/asciidoctor-mathjax'
 ui:
   bundle:
     url: https://github.com/couchbase/docs-ui/releases/download/prod-132/ui-bundle.zip

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@antora/site-generator-default": "3.0.0-alpha.5",
     "@antora/site-generator-ms": "git+https://gitlab.com/opendevise/oss/antora-site-generator-ms#v3.0.0-alpha.3",
     "@antora/xref-validator": "git+https://gitlab.com/antora/xref-validator#v1.0.0-alpha.14",
+    "@djencks/asciidoctor-mathjax": "^0.0.7",
     "gulp": "~4.0",
     "gulp-connect": "~5.7",
     "js-yaml": "~4.1"


### PR DESCRIPTION
Asciidoc does support maths scientific, technology, engineering and maths formula with the right plugin. Fortunately, we have such a plugin which I've added to the Antora setup.