### PR TITLE
SEO changes: mapping 302 to 301

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -20,3 +20,9 @@ location ^~ /tutorials/cbl-p2p-sync-websockets/ { break; }
 location ^~ /tutorials/ {
     rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ redirect;
 }
+
+proxy_intercept_errors on;
+error_page 302 = @redirect;
+location @redirect {
+    return 301 $upstream_http_location;
+}


### PR DESCRIPTION
This is a change made to improve the SEO indexing of pages. 302 pages (marked for redirection) do not usually show up in the search engine index, so we are mapping them as permanent redirections, which are indexed.